### PR TITLE
move python deps to a requirements file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM ubuntu:20.04
 RUN apt-get update && \
     apt-get install -y curl openssh-client sshpass python3 python3-pip git-core vim jq yamllint && \
-    pip3 install ansible==4.6.0 ansible-lint==5.1.3 && \
     rm -rf /var/lib/apt/lists/*
+COPY requirements.txt /requirements/
+RUN pip3 install --no-cache-dir -r /requirements/requirements.txt
 WORKDIR /ansible
 COPY docker-entrypoint.sh /usr/bin/
 COPY ansible-ssh /usr/bin/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+ansible==4.6.0
+ansible-lint==5.1.3


### PR DESCRIPTION
Ease enabling Renovate's pip_requirements manager to find them.