### PR TITLE
Dockerfile: apt: do not install recommended packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 RUN apt-get update && \
-    apt-get install -y curl openssh-client sshpass python3 python3-pip git-core vim jq yamllint && \
+    apt-get install -y --no-install-recommends curl openssh-client sshpass python3 python3-pip git-core vim jq yamllint && \
     rm -rf /var/lib/apt/lists/*
 COPY requirements.txt /requirements/
 RUN pip3 install --no-cache-dir -r /requirements/requirements.txt


### PR DESCRIPTION
This is quite beneficial on the image size (40%+ image shrink). Do you think we currently rely on any package being present because of a recommendation instead of it being explicitly installed?